### PR TITLE
Prevent specific properties from adding px

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,19 @@
+var cssNumber = {
+  "columnCount": true,
+  "fillOpacity": true,
+  "fontWeight": true,
+  "lineHeight": true,
+  "opacity": true,
+  "orphans": true,
+  "widows": true,
+  "zIndex": true,
+  "zoom": true
+};
 
 module.exports = function(el, obj){
   for (var key in obj) {
     var val = obj[key];
-    if ('number' == typeof val) val += 'px';
+    if ('number' == typeof val && !cssNumber[key]) val += 'px';
     el.style[key] = val;
   }
 };

--- a/test.js
+++ b/test.js
@@ -11,7 +11,10 @@ css(el, {
   top: 5,
   left: 5,
   width: 1,
-  height: 1
+  height: 1,
+  opacity: 1,
+  lineHeight: 1.5,
+  zIndex: 10
 })
 
 assert('block' == el.style.display)
@@ -19,3 +22,6 @@ assert('5px' == el.style.top)
 assert('5px' == el.style.left)
 assert('1px' == el.style.width)
 assert('1px' == el.style.height)
+assert('1' == el.style.opacity)
+assert('1.5' == el.style.lineHeight)
+assert('10' == el.style.zIndex)


### PR DESCRIPTION
As long as [jQuery’s css implementation](https://github.com/jquery/jquery/blob/master/src/css.js#L159) covers, several properties should be excluded from being _auto-px_ ed.

_(I know this `cssNumber` objects are a bit ugly, so please correct me if you have preferred coding style for these cases.)_

Related to #4.

Thanks.
