### PR TITLE
Update prop.js

### DIFF
--- a/lib/prop.js
+++ b/lib/prop.js
@@ -17,7 +17,7 @@ module.exports = prop;
  */
 
 var cssProps = {
-  'float': 'cssFloat' in document.body.style ? 'cssFloat' : 'styleFloat'
+  'float': 'cssFloat' in document.documentElement.style ? 'cssFloat' : 'styleFloat'
 };
 
 /**


### PR DESCRIPTION
Feature checking on document.documentElement instead of document.body - this way it doesn't require `<body>` to be present at the time the script is loaded.
