### PR TITLE
fix: set style (e.g. top) to 0 gets ignored

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -50,7 +50,7 @@ function style(el, prop, val, extra) {
   var style = el.style;
   var type = typeof val;
 
-  if (!val) return get(el, prop, orig, extra);
+  if ('undefined' === typeof val) return get(el, prop, orig, extra);
 
   prop = property(prop, style);
 

--- a/lib/style.js
+++ b/lib/style.js
@@ -50,7 +50,7 @@ function style(el, prop, val, extra) {
   var style = el.style;
   var type = typeof val;
 
-  if ('undefined' === typeof val) return get(el, prop, orig, extra);
+  if ('undefined' === type) return get(el, prop, orig, extra);
 
   prop = property(prop, style);
 


### PR DESCRIPTION
This PR fixes a bug where setting a style e.g. `css(elt, 'top', 0)` is ignored.
