### PR TITLE
Don't use browser alias for component-each dependency

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -2,7 +2,7 @@
  * Module Dependencies
  */
 
-var each = require('each');
+var each = require('component-each');
 var css = require('./css');
 var cssShow = { position: 'absolute', visibility: 'hidden', display: 'block' };
 var pnum = (/[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/).source;

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "load-styles": "^1.0.1",
     "component-test2": "*"
   },
-  "browser": {
-    "each": "component-each"
-  },
   "license": "MIT",
   "component": {
     "scripts": {


### PR DESCRIPTION
This way, `component-css` won't break node code/tests when imported.